### PR TITLE
🔧 打包改为umd格式 可支持到jsbin这类环境

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,13 @@ let path = require('path');
 
 module.exports = {
   entry: { index: './src/' },
-  output: { filename: '[name].min.js', path: path.resolve('dist') },
+  output: {
+    libraryTarget: 'umd',
+    libraryExport: 'default',
+    library: 'Genji',
+    filename: '[name].min.js',
+    path: path.resolve('dist')
+  },
   mode: 'production',
   module: {
     rules: [


### PR DESCRIPTION
打包改为umd格式 可支持到jsbin这类环境
--> https://github.com/fritx/gallery.code/commit/da6bcccddf810d2ac2b1714345e80a0c9ded2ef5

live demo: https://coldemo.github.io/#/playground/genji.jsx

```js
// load - https://unpkg.com/genjijs
let { Genji } = window
let genji = new Genji({ /*...*/ })
```

另外我注意到项目还可以再 npm run build 并push一下 cc @huangruichang 
即使在这个PR之前 dist/index.min.js 就已经有改动未push了

![image](https://user-images.githubusercontent.com/6647633/79044459-cfd35300-7c37-11ea-85b2-b3a6ebb500da.png)

几种bundle引入方式 npm test 测试都通过哈

```js
// *.test.js
// import Genji from '../../src';
// import Genji from '../../';    // 默认 lib/index.js
import Genji from '../../dist/index.min.js';
```